### PR TITLE
Fix Mistypo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ urlpatterns = [
         name='index'),
     url(r'^api/', include('api.urls')),
     url(r'^admin/', admin.site.urls),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')) # login, logout 등 사용,
+    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')), # login, logout 등 사용
     url(r'^(home)|(moim)/', TemplateView.as_view(template_name='index.html'), name='route')
 ]
 ```


### PR DESCRIPTION
README에 콤마 하나가 주석처리 되어있어서 README에 있는 그대로 입력하면 문법 에러가 발생해서, 고쳐봤습니다! 